### PR TITLE
fix(deps): patch pyasn1 DoS vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,8 +61,8 @@ proto-plus==1.23.0
 protobuf==4.25.3
 ptyprocess==0.7.0
 pure-eval==0.2.2
-pyasn1==0.5.1
-pyasn1-modules==0.3.0
+pyasn1==0.6.4
+pyasn1-modules==0.4.2
 pydantic==2.6.4
 pydantic_core==2.16.3
 Pygments==2.17.2


### PR DESCRIPTION
Applies the tested Instinct patch from the emailed Dependabot remediation set.

- pyasn1 0.5.1 → 0.6.4
- pyasn1-modules 0.3.0 → 0.4.2
- intentionally leaves protobuf at 4.25.3; the existing Dependabot proposal to 7.34.0rc1 is not included because it may break google-generativeai 0.4.1

Instinct reported that this pair resolves cleanly and clears both pyasn1 DoS alerts.